### PR TITLE
Extract material-ui specific code in Root.js into a decorator

### DIFF
--- a/src/javascript/Root.js
+++ b/src/javascript/Root.js
@@ -2,8 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { Router, Route } from 'react-router';
 import { Provider } from 'react-redux';
 import { store } from './redux';
-import mui from 'material-ui';
-import theme from './config/theme';
+import withMaterialUI from './decorators/withMaterialUI';
 import * as hooks from './hooks';
 
 import Blog from './views/Blog';
@@ -12,27 +11,10 @@ import Login from './views/Login';
 
 hooks.bootstrap(store)();
 
-export default class Root extends Component {
+@withMaterialUI
+class Root extends Component {
   static propTypes = {
     history: PropTypes.object.isRequired
-  }
-
-  /*
-   For more details: https://github.com/callemall/material-ui#usage
-   Pass material-ui theme through child context
-   We are doing this here so we don't have to do it anywhere else.
-   */
-  static childContextTypes = {
-    muiTheme: React.PropTypes.object
-  }
-
-  getChildContext() {
-    const ThemeManager = new mui.Styles.ThemeManager();
-    ThemeManager.setTheme(theme);
-
-    return {
-      muiTheme: ThemeManager.getCurrentTheme()
-    };
   }
 
   render() {
@@ -53,3 +35,5 @@ export default class Root extends Component {
     );
   }
 }
+
+export default Root;

--- a/src/javascript/decorators/withMaterialUI.js
+++ b/src/javascript/decorators/withMaterialUI.js
@@ -1,0 +1,30 @@
+import React, { PropTypes } from 'react'; // eslint-disable-line no-unused-vars
+import mui from 'material-ui';
+import theme from '../config/theme';
+
+export default function withMaterialUI(ComposedComponent) {
+  return class MaterialUI {
+    /*
+     For more details: https://github.com/callemall/material-ui#usage
+     Pass material-ui theme through child context
+     We are doing this here so we don't have to do it anywhere else.
+     */
+    static childContextTypes = {
+      muiTheme: React.PropTypes.object
+    }
+
+    getChildContext() {
+      const ThemeManager = new mui.Styles.ThemeManager();
+      ThemeManager.setTheme(theme);
+
+      return {
+        muiTheme: ThemeManager.getCurrentTheme()
+      };
+    }
+
+    render() {
+      let { context, ...other } = this.props; // eslint-disable-line no-unused-vars
+      return <ComposedComponent {...other} />;
+    }
+  };
+}


### PR DESCRIPTION
Looks cleaner and is a good example how to use decorators in a meaningful way.
